### PR TITLE
Add --mise flag to hk install command in setup task

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -7,7 +7,7 @@ hk = "1.42.0"
 description = "Install required tools and configure git hooks (run once after clone)."
 run = [
   "mise install",
-  "hk install",
+  "hk install --mise",
 ]
 
 [tasks.validate-renovate]


### PR DESCRIPTION
## Summary
Updated the `setup` task in `mise.toml` to pass the `--mise` flag when installing git hooks via the `hk` command.

## Changes
- Modified the `hk install` command to include the `--mise` flag: `hk install --mise`
  - This ensures that git hooks are installed with mise-specific configuration during the initial setup process

## Details
The `--mise` flag is now passed to the `hk install` command in the setup task, which runs after cloning the repository. This likely enables mise-aware hook installation or configuration that integrates better with the mise tool ecosystem.

https://claude.ai/code/session_01Vu4dw8nwNohGrXimgmNHYZ